### PR TITLE
feat(Reddit): Add `Colorize comment indent lines` patch

### DIFF
--- a/extensions/reddit/frontpage/src/main/java/dev/jkcarino/extension/reddit/frontpage/CommentIndentColorPatch.java
+++ b/extensions/reddit/frontpage/src/main/java/dev/jkcarino/extension/reddit/frontpage/CommentIndentColorPatch.java
@@ -1,0 +1,23 @@
+package dev.jkcarino.extension.reddit.frontpage;
+
+@SuppressWarnings("unused")
+public final class CommentIndentColorPatch {
+
+    private static final long[] COLORS = {
+            0xFF2A9D8FL, 0xFFC96B2CL,
+            0xFF7A8F3AL, 0xFF8C4A5BL,
+            0xFF4A6FA5L, 0xFFB85C38L,
+            0xFF6B7A2BL, 0xFF7B5E8EL
+    };
+
+    private static final int COMPOSE_COLOR_SHIFT = 32;
+
+    public static long getColorForDepth(int depth) {
+        if (depth <= 0) {
+            return COLORS[0] << COMPOSE_COLOR_SHIFT;
+        }
+
+        int index = (depth - 1) % COLORS.length;
+        return COLORS[index] << COMPOSE_COLOR_SHIFT;
+    }
+}

--- a/patches/src/main/kotlin/dev/jkcarino/adobo/patches/reddit/layout/commentindent/CommentIndentColorPatch.kt
+++ b/patches/src/main/kotlin/dev/jkcarino/adobo/patches/reddit/layout/commentindent/CommentIndentColorPatch.kt
@@ -1,0 +1,122 @@
+package dev.jkcarino.adobo.patches.reddit.layout.commentindent
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.patch.stringOption
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderArrayPayload
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction31t
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
+import dev.jkcarino.adobo.patches.reddit.misc.firebase.spoofCertificateHashPatch
+import dev.jkcarino.adobo.patches.reddit.shared.COMPATIBILITY_REDDIT
+
+@Suppress("unused")
+val commentIndentColorPatch = bytecodePatch(
+    name = "Colorize comment indent lines",
+    description = "Replaces the default gray comment indent lines with color-coded lines."
+) {
+    compatibleWith(COMPATIBILITY_REDDIT)
+
+    extendWith("extensions/reddit/frontpage.mpe")
+
+    dependsOn(spoofCertificateHashPatch)
+
+    val indentLineColors =
+        presetColors.mapIndexed { index, colors ->
+            val depth = index + 1
+
+            stringOption(
+                key = "indentLineColors$depth",
+                default = colors.values.first(),
+                values = colors,
+                title = "Line color $depth",
+                description = "The hex color (#RRGGBB or #AARRGGBB) " +
+                    "for comment indent line at depth $depth."
+            ) { color ->
+                val colorRegex = """^#?([0-9a-fA-F]{6}|[0-9a-fA-F]{8})$""".toRegex()
+                !color.isNullOrEmpty() && color.matches(colorRegex)
+            }
+        }
+
+    execute {
+        CommentIndentColorPatchFingerprint.method.apply {
+            val arraySizeIndex =
+                CommentIndentColorPatchFingerprint.instructionMatches.first().index
+
+            val colorsIndex =
+                CommentIndentColorPatchFingerprint.instructionMatches.last().index
+            val colorsInstructions =
+                getInstruction<BuilderInstruction31t>(colorsIndex)
+
+            val lineColors = indentLineColors.map { it.value!! }
+            val lineColorsSize = indentLineColors.size
+            val colors =
+                lineColors.map { color ->
+                    val hex = color.trim().removePrefix("#")
+                    val argb = if (hex.length == 6) "FF$hex" else hex
+                    argb.toLong(16)
+                }
+
+            val arrayPayloadIndex = colorsInstructions.target.location.index
+            val arrayPayloadInstruction = getInstruction<BuilderArrayPayload>(arrayPayloadIndex)
+            val lineColorsArrayPayload =
+                BuilderArrayPayload(
+                    arrayPayloadInstruction.elementWidth,
+                    colors
+                )
+
+            replaceInstruction(
+                index = arraySizeIndex,
+                smaliInstruction = "const/16 v0, $lineColorsSize"
+            )
+            replaceInstruction(
+                index = arrayPayloadIndex,
+                instruction = lineColorsArrayPayload
+            )
+        }
+
+        CommentIndentDrawInvokeFingerprint.method.apply {
+            val extensionClass = CommentIndentColorPatchFingerprint.definingClass
+            val drawLineIndex =
+                CommentIndentDrawInvokeFingerprint.instructionMatches.last().index
+
+            val alphaIndex =
+                CommentIndentAlphaInvokeFingerprint.instructionMatches.last().index
+            val alphaRegister =
+                CommentIndentAlphaInvokeFingerprint.method
+                    .getInstruction<TwoRegisterInstruction>(alphaIndex)
+                    .registerA
+
+            addInstruction(
+                index = drawLineIndex,
+                smaliInstructions = "const/high16 v$alphaRegister, 0x3f800000"
+            )
+
+            val strokeCapButtIndex =
+                CommentIndentDrawInvokeFingerprint.instructionMatches.first().index
+
+            val colorRegister =
+                CommentIndentDrawInvokeFingerprint.method
+                    .getInstruction<TwoRegisterInstruction>(strokeCapButtIndex - 1)
+                    .registerA
+
+            val depthIndex =
+                CommentIndentAlphaInvokeFingerprint.instructionMatches.first().index
+            val depthRegister =
+                CommentIndentAlphaInvokeFingerprint.method
+                    .getInstruction<TwoRegisterInstruction>(depthIndex)
+                    .registerA
+
+            addInstructions(
+                index = strokeCapButtIndex,
+                smaliInstructions = """
+                    move v$colorRegister, v$depthRegister
+                    invoke-static {v$colorRegister}, $extensionClass->getColorForDepth(I)J
+                    move-result-wide v$colorRegister
+                """
+            )
+        }
+    }
+}

--- a/patches/src/main/kotlin/dev/jkcarino/adobo/patches/reddit/layout/commentindent/Fingerprints.kt
+++ b/patches/src/main/kotlin/dev/jkcarino/adobo/patches/reddit/layout/commentindent/Fingerprints.kt
@@ -1,0 +1,41 @@
+package dev.jkcarino.adobo.patches.reddit.layout.commentindent
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.InstructionLocation.MatchAfterImmediately
+import app.morphe.patcher.InstructionLocation.MatchFirst
+import app.morphe.patcher.literal
+import app.morphe.patcher.opcode
+import com.android.tools.smali.dexlib2.Opcode
+
+internal object CommentIndentColorPatchFingerprint : Fingerprint(
+    definingClass = "Ldev/jkcarino/extension/reddit/frontpage/CommentIndentColorPatch;",
+    name = "<clinit>",
+    filters = listOf(
+        opcode(Opcode.CONST_16, MatchFirst()),
+        opcode(Opcode.FILL_ARRAY_DATA)
+    )
+)
+
+internal object CommentIndentAlphaInvokeFingerprint : Fingerprint(
+    name = "invoke",
+    returnType = "Ljava/lang/Object;",
+    parameters = listOf("Ljava/lang/Object;"),
+    filters = listOf(
+        opcode(Opcode.MOVE),
+        opcode(Opcode.IGET_BOOLEAN, MatchAfterImmediately()),
+        opcode(Opcode.IF_EQZ, MatchAfterImmediately()),
+        literal(
+            literal = 0x3ecccccd,
+            location = MatchAfterImmediately()
+        ),
+        opcode(Opcode.MOVE, MatchAfterImmediately()),
+    )
+)
+
+internal object CommentIndentDrawInvokeFingerprint : Fingerprint(
+    classFingerprint = CommentIndentAlphaInvokeFingerprint,
+    filters = listOf(
+        opcode(Opcode.CONST_4),
+        opcode(Opcode.INVOKE_STATIC_RANGE, MatchAfterImmediately()),
+    )
+)

--- a/patches/src/main/kotlin/dev/jkcarino/adobo/patches/reddit/layout/commentindent/Fingerprints.kt
+++ b/patches/src/main/kotlin/dev/jkcarino/adobo/patches/reddit/layout/commentindent/Fingerprints.kt
@@ -28,7 +28,7 @@ internal object CommentIndentAlphaInvokeFingerprint : Fingerprint(
             literal = 0x3ecccccd,
             location = MatchAfterImmediately()
         ),
-        opcode(Opcode.MOVE, MatchAfterImmediately()),
+        opcode(Opcode.MOVE, MatchAfterImmediately())
     )
 )
 
@@ -36,6 +36,6 @@ internal object CommentIndentDrawInvokeFingerprint : Fingerprint(
     classFingerprint = CommentIndentAlphaInvokeFingerprint,
     filters = listOf(
         opcode(Opcode.CONST_4),
-        opcode(Opcode.INVOKE_STATIC_RANGE, MatchAfterImmediately()),
+        opcode(Opcode.INVOKE_STATIC_RANGE, MatchAfterImmediately())
     )
 )

--- a/patches/src/main/kotlin/dev/jkcarino/adobo/patches/reddit/layout/commentindent/PresetColors.kt
+++ b/patches/src/main/kotlin/dev/jkcarino/adobo/patches/reddit/layout/commentindent/PresetColors.kt
@@ -32,7 +32,7 @@ internal val presetColors =
             "Nord (Deep Aurora)" to "#5E81AC",
             "Solarized (Moss Green)" to "#859900",
             "Monokai (Sunset Amber)" to "#FD971F",
-            "Synthwave (Electric Cyan)" to "#2DE2E6"
+            "Synthwave (Electric Cyan)" to "#2DE2E6",
         ),
         mapOf(
             "Default (Slate Blue)" to "#4A6FA5",
@@ -40,7 +40,7 @@ internal val presetColors =
             "Nord (Fjord Wave)" to "#6D8FB3",
             "Solarized (Deep Cyan)" to "#2AA198",
             "Monokai (Electric Cyan)" to "#66D9EF",
-            "Synthwave (Miami Sunset)" to "#FF5FA2"
+            "Synthwave (Miami Sunset)" to "#FF5FA2",
         ),
         mapOf(
             "Default (Rust Clay)" to "#B85C38",
@@ -48,7 +48,7 @@ internal val presetColors =
             "Nord (Winter Denim)" to "#7AA0C4",
             "Solarized (Ocean Blue)" to "#268BD2",
             "Monokai (Vivid Purple)" to "#AE81FF",
-            "Synthwave (Rad Orange)" to "#FF8A3D"
+            "Synthwave (Rad Orange)" to "#FF8A3D",
         ),
         mapOf(
             "Default (Juniper Berry)" to "#6B7A2B",
@@ -56,7 +56,7 @@ internal val presetColors =
             "Nord (Powder Blue)" to "#8BB2D1",
             "Solarized (Cosmic Iris)" to "#6C71C4",
             "Monokai (Vintage Straw)" to "#E6DB74",
-            "Synthwave (Retro Gold)" to "#FFD166"
+            "Synthwave (Retro Gold)" to "#FFD166",
         ),
         mapOf(
             "Default (Heather Purple)" to "#7B5E8E",
@@ -64,6 +64,6 @@ internal val presetColors =
             "Nord (Pale Ice)" to "#9BC4DC",
             "Solarized (Royal Magenta)" to "#D33682",
             "Monokai (Stark Frost)" to "#F8F8F2",
-            "Synthwave (Arcade Lime)" to "#3CFF7F"
+            "Synthwave (Arcade Lime)" to "#3CFF7F",
         )
     )

--- a/patches/src/main/kotlin/dev/jkcarino/adobo/patches/reddit/layout/commentindent/PresetColors.kt
+++ b/patches/src/main/kotlin/dev/jkcarino/adobo/patches/reddit/layout/commentindent/PresetColors.kt
@@ -1,0 +1,69 @@
+package dev.jkcarino.adobo.patches.reddit.layout.commentindent
+
+internal val presetColors =
+    listOf(
+        mapOf(
+            "Default (Teal Cascade)" to "#2A9D8F",
+            "Material (Crimson Flash)" to "#F44336",
+            "Nord (Frost Mint)" to "#8FBCBB",
+            "Solarized (Crimson Ember)" to "#DC322F",
+            "Monokai (Charcoal Stone)" to "#272822",
+            "Synthwave (Neon Blizzard)" to "#0066FF",
+        ),
+        mapOf(
+            "Default (Burnt Apricot)" to "#C96B2C",
+            "Material (Sunset Blaze)" to "#FF5722",
+            "Nord (Ice Shard)" to "#88C0D0",
+            "Solarized (Rust Orange)" to "#CB4B16",
+            "Monokai (Neon Pink)" to "#F92672",
+            "Synthwave (Laser Pink)" to "#FF2E88",
+        ),
+        mapOf(
+            "Default (Olive Moss)" to "#7A8F3A",
+            "Material (Marigold Glow)" to "#FF9800",
+            "Nord (Arctic Skies)" to "#81A1C1",
+            "Solarized (Dark Ochre)" to "#B58900",
+            "Monokai (Lime Pop)" to "#A6E22E",
+            "Synthwave (Cyber Violet)" to "#9B5CFF",
+        ),
+        mapOf(
+            "Default (Muted Mulberry)" to "#8C4A5B",
+            "Material (Honey Gold)" to "#FFC107",
+            "Nord (Deep Aurora)" to "#5E81AC",
+            "Solarized (Moss Green)" to "#859900",
+            "Monokai (Sunset Amber)" to "#FD971F",
+            "Synthwave (Electric Cyan)" to "#2DE2E6"
+        ),
+        mapOf(
+            "Default (Slate Blue)" to "#4A6FA5",
+            "Material (Electric Lemon)" to "#FFEB3B",
+            "Nord (Fjord Wave)" to "#6D8FB3",
+            "Solarized (Deep Cyan)" to "#2AA198",
+            "Monokai (Electric Cyan)" to "#66D9EF",
+            "Synthwave (Miami Sunset)" to "#FF5FA2"
+        ),
+        mapOf(
+            "Default (Rust Clay)" to "#B85C38",
+            "Material (Lime Zing)" to "#CDDC39",
+            "Nord (Winter Denim)" to "#7AA0C4",
+            "Solarized (Ocean Blue)" to "#268BD2",
+            "Monokai (Vivid Purple)" to "#AE81FF",
+            "Synthwave (Rad Orange)" to "#FF8A3D"
+        ),
+        mapOf(
+            "Default (Juniper Berry)" to "#6B7A2B",
+            "Material (Sprout Green)" to "#8BC34A",
+            "Nord (Powder Blue)" to "#8BB2D1",
+            "Solarized (Cosmic Iris)" to "#6C71C4",
+            "Monokai (Vintage Straw)" to "#E6DB74",
+            "Synthwave (Retro Gold)" to "#FFD166"
+        ),
+        mapOf(
+            "Default (Heather Purple)" to "#7B5E8E",
+            "Material (Shamrock Green)" to "#4CAF50",
+            "Nord (Pale Ice)" to "#9BC4DC",
+            "Solarized (Royal Magenta)" to "#D33682",
+            "Monokai (Stark Frost)" to "#F8F8F2",
+            "Synthwave (Arcade Lime)" to "#3CFF7F"
+        )
+    )


### PR DESCRIPTION
This PR adds the `Colorize comment indent lines` patch that replaces the default gray (with opacity progression) indent lines in Reddit comments with color-coded ones, one color per nesting depth (you can choose from the preset colors or select your own custom color).

**Preset colors:**
- Default
- Material
- Nord
- Solarized
- Monokai
- Synthwave (see the 2nd screenshot)

### Screenshots

| Before | After |
|--------|--------|
| <img width="384" alt="Default indent lines color" src="https://github.com/user-attachments/assets/95b3a7ba-84d9-4a1c-adec-519843878ed1" /> | <img width="384" alt="Color-coded indent lines" src="https://github.com/user-attachments/assets/b0c35cca-3f07-4942-b17a-da635a6db51d" /> |


