### PR TITLE
feat(Gboard - Enable OCR feature): Always show Scan Text option regardless of language

### DIFF
--- a/patches/src/main/kotlin/dev/jkcarino/adobo/patches/google/gboard/featureflags/Fingerprints.kt
+++ b/patches/src/main/kotlin/dev/jkcarino/adobo/patches/google/gboard/featureflags/Fingerprints.kt
@@ -24,3 +24,18 @@ internal val booleanFlagFingerprint = { flag: String ->
         )
     )
 }
+
+internal val stringFlagFingerprint = { flag: String ->
+    Fingerprint(
+        accessFlags = listOf(AccessFlags.STATIC, AccessFlags.CONSTRUCTOR),
+        returnType = "V",
+        parameters = listOf(),
+        filters = listOf(
+            string(flag),
+            opcode(Opcode.CONST_STRING, MatchAfterImmediately()),
+            opcode(Opcode.INVOKE_STATIC, MatchAfterImmediately()),
+            opcode(Opcode.MOVE_RESULT_OBJECT, MatchAfterImmediately()),
+            opcode(Opcode.SPUT_OBJECT, MatchAfterImmediately())
+        )
+    )
+}

--- a/patches/src/main/kotlin/dev/jkcarino/adobo/patches/google/gboard/featureflags/ToggleFeatureFlag.kt
+++ b/patches/src/main/kotlin/dev/jkcarino/adobo/patches/google/gboard/featureflags/ToggleFeatureFlag.kt
@@ -12,7 +12,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 context(_: BytecodePatchContext)
-internal fun toggleFeatureFlag(
+fun toggleFeatureFlag(
     flag: String,
     enabled: Boolean,
 ) {
@@ -65,5 +65,23 @@ internal fun toggleFeatureFlag(
                 smaliInstructions = smaliInstruction
             )
         }
+    }
+}
+
+context(_: BytecodePatchContext)
+fun toggleFeatureFlag(
+    flag: String,
+    value: String,
+) {
+    val fingerprint = stringFlagFingerprint(flag)
+
+    fingerprint.method.apply {
+        val targetIndex = fingerprint.instructionMatches[1].index
+        val register = getInstruction<OneRegisterInstruction>(targetIndex).registerA
+
+        replaceInstruction(
+            index = targetIndex,
+            smaliInstruction = "const-string v$register, $value"
+        )
     }
 }

--- a/patches/src/main/kotlin/dev/jkcarino/adobo/patches/google/gboard/misc/ocr/EnableOcrPatch.kt
+++ b/patches/src/main/kotlin/dev/jkcarino/adobo/patches/google/gboard/misc/ocr/EnableOcrPatch.kt
@@ -23,5 +23,11 @@ val enableOcrPatch = bytecodePatch(
             flag = "enable_ocr",
             enabled = true
         )
+
+        // Enable OCR for all languages (default is English only)
+        toggleFeatureFlag(
+            flag = "enabled_ocr_language_tags",
+            value = "\"\""
+        )
     }
 }


### PR DESCRIPTION
This PR adds always-on support for Gboard's Scan Text (OCR) option so it appears regardless of keyboard language. Note that while the option now shows for all languages, text extraction currently only supports the Latin alphabet. This resolves #24.