### PR TITLE
feat(Reddit - Colorize comment indent lines): Add `Show indent line at current depth only` option

### DIFF
--- a/patches/src/main/kotlin/dev/jkcarino/adobo/patches/reddit/layout/commentindent/CommentIndentColorPatch.kt
+++ b/patches/src/main/kotlin/dev/jkcarino/adobo/patches/reddit/layout/commentindent/CommentIndentColorPatch.kt
@@ -9,6 +9,7 @@ import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.stringOption
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderArrayPayload
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction31t
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 import dev.jkcarino.adobo.patches.reddit.misc.firebase.spoofCertificateHashPatch
 import dev.jkcarino.adobo.patches.reddit.shared.COMPATIBILITY_REDDIT
@@ -133,9 +134,23 @@ val commentIndentColorPatch = bytecodePatch(
                         .getInstruction<TwoRegisterInstruction>(indentLoopInitIndex)
                         .registerA
 
+                // Change loop start from 1 (draw all depths) to current depth (draw only one)
                 replaceInstruction(
                     index = depthIndex,
                     smaliInstruction = "move v$depthRegister, v$depthValueRegister"
+                )
+
+                val strokeWidthIndex =
+                    CommentIndentStrokeWidthFingerprint.instructionMatches.first().index
+                val strokeWidthRegister =
+                    CommentIndentStrokeWidthFingerprint.method
+                        .getInstruction<OneRegisterInstruction>(strokeWidthIndex)
+                        .registerA
+
+                // Increase indent line stroke width from 1dp to 2dp
+                replaceInstruction(
+                    index = strokeWidthIndex,
+                    smaliInstruction = "const/high16 v$strokeWidthRegister, 0x40000000"
                 )
             }
         }

--- a/patches/src/main/kotlin/dev/jkcarino/adobo/patches/reddit/layout/commentindent/CommentIndentColorPatch.kt
+++ b/patches/src/main/kotlin/dev/jkcarino/adobo/patches/reddit/layout/commentindent/CommentIndentColorPatch.kt
@@ -4,6 +4,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.patch.booleanOption
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.stringOption
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderArrayPayload
@@ -22,6 +23,12 @@ val commentIndentColorPatch = bytecodePatch(
     extendWith("extensions/reddit/frontpage.mpe")
 
     dependsOn(spoofCertificateHashPatch)
+
+    val isCurrentLevelOnly by booleanOption(
+        key = "isCurrentLevelOnly",
+        title = "Show indent line at current depth only",
+        default = false
+    )
 
     val indentLineColors =
         presetColors.mapIndexed { index, colors ->
@@ -117,6 +124,20 @@ val commentIndentColorPatch = bytecodePatch(
                     move-result-wide v$colorRegister
                 """
             )
+
+            if (isCurrentLevelOnly!!) {
+                val indentLoopInitIndex =
+                    CommentIndentLoopInitFingerprint.instructionMatches.first().index
+                val depthValueRegister =
+                    CommentIndentAlphaInvokeFingerprint.method
+                        .getInstruction<TwoRegisterInstruction>(indentLoopInitIndex)
+                        .registerA
+
+                replaceInstruction(
+                    index = depthIndex,
+                    smaliInstruction = "move v$depthRegister, v$depthValueRegister"
+                )
+            }
         }
     }
 }

--- a/patches/src/main/kotlin/dev/jkcarino/adobo/patches/reddit/layout/commentindent/Fingerprints.kt
+++ b/patches/src/main/kotlin/dev/jkcarino/adobo/patches/reddit/layout/commentindent/Fingerprints.kt
@@ -3,6 +3,7 @@ package dev.jkcarino.adobo.patches.reddit.layout.commentindent
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.InstructionLocation.MatchAfterImmediately
 import app.morphe.patcher.InstructionLocation.MatchFirst
+import app.morphe.patcher.fieldAccess
 import app.morphe.patcher.literal
 import app.morphe.patcher.opcode
 import com.android.tools.smali.dexlib2.Opcode
@@ -37,5 +38,15 @@ internal object CommentIndentDrawInvokeFingerprint : Fingerprint(
     filters = listOf(
         opcode(Opcode.CONST_4),
         opcode(Opcode.INVOKE_STATIC_RANGE, MatchAfterImmediately())
+    )
+)
+
+internal object CommentIndentLoopInitFingerprint : Fingerprint(
+    classFingerprint = CommentIndentAlphaInvokeFingerprint,
+    filters = listOf(
+        fieldAccess(type = "I"),
+        opcode(Opcode.CONST_4, MatchAfterImmediately()),
+        opcode(Opcode.IF_GT, MatchAfterImmediately()),
+        opcode(Opcode.MOVE, MatchAfterImmediately())
     )
 )

--- a/patches/src/main/kotlin/dev/jkcarino/adobo/patches/reddit/layout/commentindent/Fingerprints.kt
+++ b/patches/src/main/kotlin/dev/jkcarino/adobo/patches/reddit/layout/commentindent/Fingerprints.kt
@@ -50,3 +50,10 @@ internal object CommentIndentLoopInitFingerprint : Fingerprint(
         opcode(Opcode.MOVE, MatchAfterImmediately())
     )
 )
+
+internal object CommentIndentStrokeWidthFingerprint : Fingerprint(
+    classFingerprint = CommentIndentAlphaInvokeFingerprint,
+    filters = listOf(
+        literal(literal = 0x3f800000)
+    )
+)


### PR DESCRIPTION
This PR adds a `Show indent line at current depth only` option to the `Colorize comment indent lines` patch. This feature is similar to [Infinity](https://github.com/Docile-Alligator/Infinity-For-Reddit) / [Continuum](https://github.com/cygnusx-1-org/continuum)'s (fork of Infinity) `Show Only One Comment Level Indicator` feature. This closes #38.

## Screenshot

**Show indent line at current depth only**:

| Before | After |
|--------|--------|
| <img width="400" alt="reddit-comment-indent-line-default" src="https://github.com/user-attachments/assets/9ccd55cf-7826-46f1-8144-01c4d96b02b0" /> | <img width="400" alt="reddit-comment-indent-lines" src="https://github.com/user-attachments/assets/4202ed2b-2e23-4ac0-8271-b0c8b63bc7fb" /> |



